### PR TITLE
Add GitHub actions workflow to test building the LDWizard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Build
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,16 @@ name: Build
 
 on:
   push:
+    branches: [ "main" ]
+    paths:
+    - "*.json"
+    - "yarn.lock"
+    - "src/**"
+    - "webpack/**"
+    - "docker/**"
+    - ".github/workflows/build.yml"
   pull_request:
+    branches: [ "main" ]
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Run tests
+
+on:
+  push:
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install yarn
+      run: |
+        npm install --global yarn
+
+    - name: Install dependencies
+      run: |
+        yarn install --frozen-lockfile
+
+    - name: Build the LDWizard
+      run: |
+        yarn build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+[![Build](https://github.com/pldn/LDWizard/actions/workflows/build.yml/badge.svg)](https://github.com/pldn/LDWizard/actions/workflows/build.yml)
+
 Welcome to our LDWizard Community and many thanks for taking the time to contribute!.
 
 In this document you find guidance on how you can contribute to our community activities by Developing local LDWizard code.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 LD Wizard is a framework for creating end-user focused Graphical User Interfaces (GUIs) that simplify the creation and publication of linked data.
 
+[![Build](https://github.com/pldn/LDWizard/actions/workflows/build.yml/badge.svg)](https://github.com/pldn/LDWizard/actions/workflows/build.yml)
+
 ## 1. LD Wizard Project
 
 So far, the following LDWizard variants have been configured from the LDWizard Core:

--- a/webpack/runtimeConfig.ts
+++ b/webpack/runtimeConfig.ts
@@ -1,33 +1,31 @@
 /**
  * This file is a placeHolder to be used during development. The LDWizard-build script will replace the config file
+ * It uses a detailed LDWizard config with column refinments
  */
-window.wizardConfig = {};
+const wizardConfig = {
+   appName: "LDWizard - example",
+   defaultBaseIri: "https://w3id.org/my-wizard/",
+   primaryColor: "#4caf50", // green
+   secondaryColor: "#1565c0", // blue
 
-// NOTE: Example of detailed LDWizard config with column refinments
-// const wizardConfig = {
-//    appName: "LDWizard - example",
-//    defaultBaseIri: "https://w3id.org/my-wizard/",
-//    primaryColor: "#4caf50", // green
-//    secondaryColor: "#1565c0", // blue
-
-//    columnRefinements: [
-//       {
-//          label: "Convert lang ISO to Lexvo URIs",
-//          type: "single" as const,
-//          description:
-//             "This transformation will take lang ISO (e.g. fr or fra) and convert it to a Lexvo URI: http://lexvo.org/id/iso639-3/eng",
-//          transformation: async (searchTerm: string) => {
-//             // const sources = ["http://vocab.getty.edu/aat/sparql"];
-//             // return getUriOfSearchTerm(sources, searchTerm);
-//             if (searchTerm.length == 3) {
-//                return `http://lexvo.org/id/iso639-3/${searchTerm}`
-//             }
-//             if (searchTerm.length == 2) {
-//                return `http://lexvo.org/id/iso639-1/${searchTerm}`
-//             }
-//             return searchTerm
-//          },
-//       },
-//    ],
-// };
-// window.wizardConfig = wizardConfig;
+   columnRefinements: [
+      {
+         label: "Convert lang ISO to Lexvo URIs",
+         type: "single" as const,
+         description:
+            "This transformation will take lang ISO (e.g. fr or fra) and convert it to a Lexvo URI: http://lexvo.org/id/iso639-3/eng",
+         transformation: async (searchTerm: string) => {
+            // const sources = ["http://vocab.getty.edu/aat/sparql"];
+            // return getUriOfSearchTerm(sources, searchTerm);
+            if (searchTerm.length == 3) {
+               return `http://lexvo.org/id/iso639-3/${searchTerm}`
+            }
+            if (searchTerm.length == 2) {
+               return `http://lexvo.org/id/iso639-1/${searchTerm}`
+            }
+            return searchTerm
+         },
+      },
+   ],
+};
+window.wizardConfig = wizardConfig;


### PR DESCRIPTION
Hi, I created a GitHub Actions to test if the LDWizard successfully builds using the default config (`yarn build`) with node 14, 16 and 18

It was requested by @GerwinBosch in https://github.com/pldn/LDWizard/issues/38, and it is really useful to check if the LDWizard properly builds on various version of NodeJS after making changes

You can see a successful run here: https://github.com/vemonet/LDWizard/actions/runs/3932622823

I put the following triggers:
* `push`: will be triggered by a push to the `main` branch, if there is a change in the paths specified (`src/`, `webpack/`, etc mainly to avoid triggering if there is just changes to a markdown file)
* `pull_request`: triggered to test if LDWizard build successfully with the changes made in the pull request
* `workflow_call`: allow to call this workflow from another GitHub Actions workflow, really convenient if you want to also have a publish workflow that is triggered when a new release is created on GitHub (so you can run the test before publishing without duplicating the workflow code)
* `workflow_dispatch`: to trigger it manually, if you want to run it on a specific branch, or for some reason the workflow did not trigger, you can trigger it yourself on any branch to check if the build passes

I added a badge at the top of `README.md` and `CONTRIBUTING.md`. Not sure if you want to have it in the README, personnally I find it really convenient to have it there because it helps to quickly spot when the workflow has failed

And I changed the default `webpack/runtimeConfig.ts` to use a custom config with column refinement, it enables to test more features of the LDWizard when in development and tests