### PR TITLE
Add import and yarrrml rebased

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+name: Build
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+    - "*.json"
+    - "yarn.lock"
+    - "src/**"
+    - "webpack/**"
+    - "docker/**"
+    - ".github/workflows/build.yml"
+  pull_request:
+    branches: [ "main" ]
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+
+  build:
+    name: Build with yarn
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install yarn
+      run: |
+        npm install --global yarn
+
+    - name: Install dependencies
+      run: |
+        yarn --frozen-lockfile
+
+    - name: Build the LDWizard
+      run: |
+        yarn build
+
+
+  docker:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build the Docker image
+      run: |
+        docker build . -f ./docker/Dockerfile -t ldwizard --build-arg CONFIG_FILE=webpack/runtimeConfig.ts

--- a/CONFIGURING.md
+++ b/CONFIGURING.md
@@ -90,8 +90,7 @@ You can create your own LD Wizard application by following these steps:
       const wizardConfig: WizardConfig = {
          // Your custom configuration comes here - see 1b. Configuration options mentioned below
       };
-
-      export default globalThis.config = wizardConfig;
+      globalThis.wizardConfig = wizardConfig;
       ```
 
 7. Run the following command to build your application:

--- a/CONFIGURING.md
+++ b/CONFIGURING.md
@@ -90,7 +90,7 @@ You can create your own LD Wizard application by following these steps:
       const wizardConfig: WizardConfig = {
          // Your custom configuration comes here - see 1b. Configuration options mentioned below
       };
-      globalThis.wizardConfig = wizardConfig;
+      export default globalThis.wizardConfig = wizardConfig;
       ```
 
 7. Run the following command to build your application:

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@mui/material": "^5.14.5",
     "@pandemicode/material-ui-dropzone": "^3.5.5",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
+    "@rmlio/yarrrml-parser": "^1.6.1",
     "@svgr/webpack": "^6.5.1",
     "@triply/triplydb": "^6.0.8",
     "@triply/utils": "1.4.2",

--- a/src/Definitions.ts
+++ b/src/Definitions.ts
@@ -2,7 +2,7 @@ import Rdf from "rdf-js";
 /**
  * General definitions
  */
-export type TransformationType = "cow" | "rml";
+export type TransformationType = "cow" | "rml" | "yarrrml";
 export type Matrix = Array<Array<string>>;
 export type Source = File | string;
 export type TransformationScript = string | {};

--- a/src/Definitions.ts
+++ b/src/Definitions.ts
@@ -82,6 +82,8 @@ export interface ApplyTransformationI {
   config: TransformationConfiguration;
   type: TransformationType;
   source: Source | Matrix;
+  wizardAppConfig: any; // It would be better to use the WizardAppConfig interface
+  // but we would need to import from config, which might create circular dependencies
 }
 /**
  * Apply the transformation to the source data
@@ -134,7 +136,7 @@ export interface SingleBaseColumnRefinement extends BaseColumnRefinement {
 export interface BulkBaseColumnRefinement extends BaseColumnRefinement {
   /**
    * Only used for `bulkTransformation`s
-   * 
+   *
    * Size of elements of total size to perform bulk opperation on
    * @example batchSize = 5 in array [1,2,3,4,5,6,7,8,9,10,11] yields:
    * first batch => 1,2,3,4,5
@@ -181,7 +183,7 @@ export interface BulkSingleColumnRefinement extends BulkBaseColumnRefinement {
   /**
    * @property a single column's values will be used for refinement/transformation
    */
-  type: "single";  
+  type: "single";
   /**
    * @param value values in column used for transformation (all row values as array)
    * @returns transformed column values
@@ -205,7 +207,7 @@ export interface BulkSingleColumnParamRefinement extends BulkBaseColumnRefinemen
    */
   type: "single-param";
   /**
-   * 
+   *
    * @param value values in column used for transformation (all row values as array)
    * @returns transformed column values
    */

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -9,6 +9,7 @@ import {
 import getCowTransformationScript from "./cowScript.ts";
 import applyTransformation from "./rocketrmlScript.ts";
 import getRmlTransformationScript from "./rmlScript.ts";
+import getYarrrmlTransformationScript from "./yarrrmlScript.ts";
 import {
   getClassSuggestions as getElasticClassSuggestions,
   getPropertySuggestions as getElasticPropertySuggestions,
@@ -131,6 +132,8 @@ export const wizardAppConfig: WizardAppConfig = {
     switch (type) {
       case "cow":
         return getCowTransformationScript(config);
+      case "yarrrml":
+        return getYarrrmlTransformationScript(config);
       case "rml":
         return getRmlTransformationScript(config);
       default:

--- a/src/config/rocketrmlScript.ts
+++ b/src/config/rocketrmlScript.ts
@@ -38,8 +38,6 @@ const applyTransformation: ApplyTransformation = async (opts) => {
     let result = await parser.parseFileLive(rmlMappings.toString(), inputFiles, options).catch((err) => { console.log(err); });
     // Convert ntriples to turtle
     const rdfParser = new Parser();
-    // NOTE: the config passed is a TransformationConfig, we would need
-    // to pass the wizardAppConfig if we want to access the global getPrefixes() function
     const prefixes = {
       '': opts.config.baseIri,
       ldwid: opts.config.baseIri + "id/",
@@ -56,7 +54,11 @@ const applyTransformation: ApplyTransformation = async (opts) => {
       pav: 'http://purl.org/pav/',
       prov: 'http://www.w3.org/ns/prov#',
       csvw: 'http://www.w3.org/ns/csvw#',
-      dbo: 'http://dbpedia.org/ontology/'
+      dbo: 'http://dbpedia.org/ontology/',
+      ...(await opts.wizardAppConfig.getPrefixes()).reduce((obj, item) => {
+        obj[item.prefixLabel] = item.iri;
+        return obj
+      }, {} as Record<string, string>)
     }
     const quads = rdfParser.parse(result, null, (prefix, namespace) => {
       prefixes[prefix] = namespace['id']

--- a/src/config/rocketrmlScript.ts
+++ b/src/config/rocketrmlScript.ts
@@ -3,6 +3,7 @@ import getRmlTransformationScript from "./rmlScript.ts";
 import { matrixToCsv } from "../utils/helpers.ts";
 import parser from "rocketrml";
 import lodash from "lodash";
+import { Parser, Writer } from "n3";
 
 /**
  * Different from the other transformation script, as it is also used in the wizard to transform the data.
@@ -34,11 +35,35 @@ const applyTransformation: ApplyTransformation = async (opts) => {
       xmlPerformanceMode: false,
       replace: false,
     };
-    const result = await parser.parseFileLive(rmlMappings.toString(), inputFiles, options).catch((err) => {
-      console.error(err);
-      throw(err)
+    let result = await parser.parseFileLive(rmlMappings.toString(), inputFiles, options).catch((err) => { console.log(err); });
+    // Convert ntriples to turtle
+    const rdfParser = new Parser();
+    // TODO: is it possible to get prefixes from getPrefixes() in the wizardAppConfig?
+    const prefixes = {
+      '': opts.config.baseIri,
+      xsd: 'http://www.w3.org/2001/XMLSchema#',
+      rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+      rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
+      schema: 'https://schema.org/',
+      foaf: 'http://xmlns.com/foaf/0.1/',
+      dc: 'http://purl.org/dc/elements/1.1/',
+      dcterms: 'http://purl.org/dc/terms/',
+      owl: 'http://www.w3.org/2002/07/owl#',
+      dcat: 'http://www.w3.org/ns/dcat#',
+      pav: 'http://purl.org/pav/',
+      prov: 'http://www.w3.org/ns/prov#',
+    }
+    const quads = rdfParser.parse(result, null, (prefix, namespace) => {
+      prefixes[prefix] = namespace['id']
+    })
+    const serializer = new Writer({ format: 'Turtle', prefixes: prefixes });
+    serializer.addQuads(quads);
+    serializer.end((error, turtleData) => {
+      if (!error) {
+        result = turtleData
+      }
     });
-    return result;
+    return result
   } else {
     throw new Error("Not supported");
   }

--- a/src/config/rocketrmlScript.ts
+++ b/src/config/rocketrmlScript.ts
@@ -38,9 +38,12 @@ const applyTransformation: ApplyTransformation = async (opts) => {
     let result = await parser.parseFileLive(rmlMappings.toString(), inputFiles, options).catch((err) => { console.log(err); });
     // Convert ntriples to turtle
     const rdfParser = new Parser();
-    // TODO: is it possible to get prefixes from getPrefixes() in the wizardAppConfig?
+    // NOTE: the config passed is a TransformationConfig, we would need
+    // to pass the wizardAppConfig if we want to access the global getPrefixes() function
     const prefixes = {
       '': opts.config.baseIri,
+      ldwid: opts.config.baseIri + "id/",
+      ldwdef: opts.config.baseIri + "def/",
       xsd: 'http://www.w3.org/2001/XMLSchema#',
       rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
       rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
@@ -52,6 +55,8 @@ const applyTransformation: ApplyTransformation = async (opts) => {
       dcat: 'http://www.w3.org/ns/dcat#',
       pav: 'http://purl.org/pav/',
       prov: 'http://www.w3.org/ns/prov#',
+      csvw: 'http://www.w3.org/ns/csvw#',
+      dbo: 'http://dbpedia.org/ontology/'
     }
     const quads = rdfParser.parse(result, null, (prefix, namespace) => {
       prefixes[prefix] = namespace['id']

--- a/src/config/yarrrmlScript.ts
+++ b/src/config/yarrrmlScript.ts
@@ -1,0 +1,19 @@
+import { TransformationScript, TransformationConfiguration } from "../Definitions.ts";
+import { Parser, Store } from "n3";
+import getRmlTransformationScript from "./rmlScript.ts";
+import convertRMLtoYAML from "@rmlio/yarrrml-parser/lib/yarrrml-generator";
+
+async function getYarrrmlTransformationScript(configuration: TransformationConfiguration): Promise<TransformationScript> {
+  const rmlString = await getRmlTransformationScript(configuration);
+  const parser = new Parser()
+  const prefixes = {}
+  const rmlStore = new Store(
+    parser.parse(rmlString.toString(), null, (prefix, namespace) => {
+      prefixes[prefix] = namespace['id']
+    })
+  )
+  const yarrrmlMappings = await convertRMLtoYAML(rmlStore.getQuads(null, null, null, null), prefixes)
+  return yarrrmlMappings;
+}
+
+export default getYarrrmlTransformationScript;

--- a/src/containers/Publish/DownloadResults.tsx
+++ b/src/containers/Publish/DownloadResults.tsx
@@ -35,7 +35,7 @@ const DownloadResults: React.FC<Props> = ({ transformationResult, refinedCsv }) 
   if (!source) return null;
 
   const rdfFileName =
-    (source && source instanceof File &&  "name" in source) ? getFileBaseName(source.name) + ".nt" : "result.nt";
+    (source && source instanceof File &&  "name" in source) ? getFileBaseName(source.name) + ".ttl" : "result.ttl";
 
   return (
     (<Card variant="outlined">

--- a/src/containers/Publish/DownloadResults.tsx
+++ b/src/containers/Publish/DownloadResults.tsx
@@ -108,8 +108,7 @@ const DownloadResults: React.FC<Props> = ({ transformationResult, refinedCsv }) 
             </CardContent>
             <CardActions>
               <SplitButton
-                // We don't propose to download YARRRML mappings if "Row number" is used as Key columns: not supported by YARRRML
-                actions={(transformationConfig.key !== undefined) ? ["rml", "yarrrml", "cow"] : ["rml", "cow"]}
+                actions={["rml", "yarrrml", "cow"]}
                 getButtonlabel={(selectedOption) => `Download ${selectedOption.toUpperCase()}`}
                 getOptionsLabel={(option) => (option === "cow" ? "CoW" : option.toUpperCase())}
                 onActionSelected={(result) =>

--- a/src/containers/Publish/DownloadResults.tsx
+++ b/src/containers/Publish/DownloadResults.tsx
@@ -16,7 +16,7 @@ interface Props {
 const DownloadResults: React.FC<Props> = ({ transformationResult, refinedCsv }) => {
   const downloadRef = React.useRef<HTMLAnchorElement>(null);
   const source = useRecoilValue(sourceState);
-  
+
   const transformationConfig = useRecoilValue(transformationConfigState);
 
 
@@ -108,7 +108,7 @@ const DownloadResults: React.FC<Props> = ({ transformationResult, refinedCsv }) 
             </CardContent>
             <CardActions>
               <SplitButton
-                actions={["rml", "cow"]}
+                actions={["rml", "yarrrml", "cow"]}
                 getButtonlabel={(selectedOption) => `Download ${selectedOption.toUpperCase()}`}
                 getOptionsLabel={(option) => (option === "cow" ? "CoW" : option.toUpperCase())}
                 onActionSelected={(result) =>
@@ -125,6 +125,8 @@ const DownloadResults: React.FC<Props> = ({ transformationResult, refinedCsv }) 
                               ? `convert.csv-metadata.json`
                               : `${refinedCsv ? fileBase + "-enriched.csv" : source?.name}-metadata.json`;
                           downloadFile(file, fileName, "application/json+ld");
+                        } else if (result === "yarrrml") {
+                          downloadFile(file, `${fileBase || "rules"}.yarrrml.yml`, "text/x-yaml");
                         } else if (result === "rml") {
                           downloadFile(file, `${fileBase || "rules"}.rml.ttl`, "text/turtle");
                         }

--- a/src/containers/Publish/DownloadResults.tsx
+++ b/src/containers/Publish/DownloadResults.tsx
@@ -108,7 +108,8 @@ const DownloadResults: React.FC<Props> = ({ transformationResult, refinedCsv }) 
             </CardContent>
             <CardActions>
               <SplitButton
-                actions={["rml", "yarrrml", "cow"]}
+                // We don't propose to download YARRRML mappings if "Row number" is used as Key columns: not supported by YARRRML
+                actions={(transformationConfig.key !== undefined) ? ["rml", "yarrrml", "cow"] : ["rml", "cow"]}
                 getButtonlabel={(selectedOption) => `Download ${selectedOption.toUpperCase()}`}
                 getOptionsLabel={(option) => (option === "cow" ? "CoW" : option.toUpperCase())}
                 onActionSelected={(result) =>
@@ -131,6 +132,9 @@ const DownloadResults: React.FC<Props> = ({ transformationResult, refinedCsv }) 
                           downloadFile(file, `${fileBase || "rules"}.rml.ttl`, "text/turtle");
                         }
                       }
+                    })
+                    .catch((e) => {
+                      console.error(`Error generating the mappings: ${e.message}`);
                     })
                 }
               />

--- a/src/containers/Publish/DownloadResults.tsx
+++ b/src/containers/Publish/DownloadResults.tsx
@@ -104,7 +104,7 @@ const DownloadResults: React.FC<Props> = ({ transformationResult, refinedCsv }) 
             <CardHeader title="Download script" avatar={<FontAwesomeIcon icon="file-code" />} />
             <CardContent className={styles.downloadContent}>
               Download the RML mappings that you can use to run the transformation yourself. The following mapping languages are
-              supported: RML, CoW.
+              supported: RML, YARRRML, CoW.
             </CardContent>
             <CardActions>
               <SplitButton

--- a/src/containers/Publish/TriplyDBPublishProcess.tsx
+++ b/src/containers/Publish/TriplyDBPublishProcess.tsx
@@ -93,7 +93,7 @@ const TriplyDBUploadProcess: React.FC<Props> = ({ transformationResult, refinedC
       // We need to get a mutable object as we create a local job
       const ds = await (await App.get(token).getAccount(selectedAccount.accountName)).getDataset(selectedDataset?.name);
       setProcessText("Uploading results");
-      await ds.importFromFiles([stringToFile(transformationResult, "results.nt", "application/n-triples")]);
+      await ds.importFromFiles([stringToFile(transformationResult, "results.ttl", "text/turtle")]);
       setProcessText("Uploading scripts");
 
       const cowScript = await wizardAppConfig.getTransformationScript(transformationConfig, "cow");

--- a/src/containers/Publish/index.tsx
+++ b/src/containers/Publish/index.tsx
@@ -251,6 +251,7 @@ function LinearProgressWithLabel(props: LinearProgressProps & { value: number })
           config: transformationConfig,
           source: tempRefinedCsv || parsedCsv,
           type: "rml",
+          wizardAppConfig: wizardAppConfig,
         });
         setTransformationResult(transformationResult);
       }

--- a/src/containers/Upload/index.tsx
+++ b/src/containers/Upload/index.tsx
@@ -59,7 +59,7 @@ const Upload: React.FC<Props> = ({ }) => {
   const sourceText =
     (source && (typeof source === "string" ? "Input selected" : `Current file: ${source.name}`)) || "No file selected";
   const mappingSourceText =
-    (mappingSource && (typeof mappingSource === "string" ? "Input selected" : `Current file: ${mappingSource.name}`)) || "No file selected";
+    (mappingSource && (typeof mappingSource === "string" ? "Input selected" : `Mapping file: ${mappingSource.name}`)) || "No file selected";
   const handleCsvParse = (sourceFile: File) => {
     setLoading(true);
     setSource(sourceFile);
@@ -382,7 +382,7 @@ const Upload: React.FC<Props> = ({ }) => {
         {source &&
           <>
             <Typography variant="body1" style={{ textAlign: "center", paddingTop: "2rem" }}>
-              Optionally you can provide a RML or YARRRML mapping file to pre-load the mappings from, or click next
+              Optionally you can provide a RML (in turtle format), or YARRRML (in YAML format) mapping file to pre-load the mappings from, or click next
             </Typography>
             <div className={styles.button}
             onDragOver={(e) => handleDragOver(e)}

--- a/src/containers/Upload/index.tsx
+++ b/src/containers/Upload/index.tsx
@@ -126,12 +126,10 @@ const Upload: React.FC<Props> = ({ }) => {
       return { ...state };
     });
     setError(undefined);
-
-    const { namedNode, blankNode } = DataFactory;
+    const { namedNode } = DataFactory;
     const rdfType = namedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
     const rr = "http://www.w3.org/ns/r2rml#"
     const rml = "http://semweb.mmlab.be/ns/rml#"
-    const regexExtractTemplate = /(.*?)\{(.*?)\}/
     // NOTE: Info about source file dont need to be extracted as a new source file is provided
 
     // First we parse the provided RML RDF file
@@ -173,7 +171,8 @@ const Upload: React.FC<Props> = ({ }) => {
         }
         //
         if (subjectMapValue) {
-          const match = subjectMapValue.match(regexExtractTemplate);
+          // We remove the /id/ fragment if present at the end to follow the LDWizard base IRI schema
+          const match = subjectMapValue.match(/(.*?)(?:id(?:#|\/))?\{(.*?)\}/);
           if (match) {
             const baseIri = match[1];
             const keyColumnName = match[2];
@@ -249,7 +248,7 @@ const Upload: React.FC<Props> = ({ }) => {
               const columnConfig = [...state.columnConfiguration];
               if (isTemplate) {
                 // Handle rr:template for IRI Prefix transformation
-                const match = poMapObjectValue.match(regexExtractTemplate);
+                const match = poMapObjectValue.match(/(.*?)\{(.*?)\}/);
                 const baseIri = match[1];
                 const keyColumnName = match[2];
                 const keyIndex = state.columnConfiguration.findIndex(obj => obj.columnName === keyColumnName);

--- a/src/containers/Upload/index.tsx
+++ b/src/containers/Upload/index.tsx
@@ -5,7 +5,9 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Papa from "papaparse";
 import { useNavigate } from "react-router-dom";
 import { useRecoilState, useSetRecoilState } from "recoil";
-import { sourceState, matrixState, transformationConfigState } from "../../state/index.ts";
+import { Parser, Store, DataFactory, Writer } from "n3";
+import RMLGenerator from "@rmlio/yarrrml-parser/lib/rml-generator";
+import { mappingSourceState, sourceState, matrixState, transformationConfigState } from "../../state/index.ts";
 import config from "../../config/index.ts";
 import * as chardet from 'chardet';
 
@@ -22,7 +24,6 @@ class EmptySpaceInColumnError extends Error {
     this.name = "EmptySpaceInColumnError";
   }
 }
-
 
 const exampleFile = config.exampleCsv
   ? new File([new Blob([config.exampleCsv], { type: "text/csv" })], "example.csv")
@@ -51,11 +52,14 @@ const Upload: React.FC<Props> = ({ }) => {
   const [error, setError] = React.useState<string>();
   const [parsedSource, setParsedSource] = useRecoilState(matrixState);
   const [source, setSource] = useRecoilState(sourceState);
+  const [mappingSource, setMappingSource] = useRecoilState(mappingSourceState);
   const [loading, setLoading] = React.useState(false);
 
   const setTransformationConfig = useSetRecoilState(transformationConfigState);
   const sourceText =
     (source && (typeof source === "string" ? "Input selected" : `Current file: ${source.name}`)) || "No file selected";
+  const mappingSourceText =
+    (mappingSource && (typeof mappingSource === "string" ? "Input selected" : `Current file: ${mappingSource.name}`)) || "No file selected";
   const handleCsvParse = (sourceFile: File) => {
     setLoading(true);
     setSource(sourceFile);
@@ -94,7 +98,6 @@ const Upload: React.FC<Props> = ({ }) => {
             };
           });
           setLoading(false);
-          navigate(`/${Step + 1}`);
         }
         catch(e){
           console.error(e, typeof e)
@@ -113,6 +116,155 @@ const Upload: React.FC<Props> = ({ }) => {
         setError(e.message);
       });
   };
+
+
+  // Parse the RML mappings file, and update the TransformationConfiguration accordingly
+  const handleRmlParse = (sourceFile: File) => {
+    setLoading(true);
+    setMappingSource(sourceFile);
+    setTransformationConfig((state) => {
+      return { ...state };
+    });
+    setError(undefined);
+
+    const { namedNode, blankNode } = DataFactory;
+    const rdfType = namedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+    const rr = "http://www.w3.org/ns/r2rml#"
+    const rml = "http://semweb.mmlab.be/ns/rml#"
+    // NOTE: Info about source file dont need to be extracted as a new source file is provided
+
+    // First we parse the provided RML RDF file
+    const parser = new Parser()
+    const prefixes = {}
+    sourceFile.text().then((rmlString) => {
+      try {
+        const store = new Store()
+        if (sourceFile.name.endsWith(".yml") || sourceFile.name.endsWith(".yaml")) {
+          // Handle when YARRRML file provided
+          const rmlGen = new RMLGenerator();
+          store.addQuads(rmlGen.convert(rmlString))
+        } else {
+          store.addQuads(
+            parser.parse(rmlString, null, (prefix, namespace) => {
+              prefixes[prefix] = namespace['id']
+            })
+          )
+        }
+
+        // Iterate RML RDF, and change the transformation config
+        // Get the TriplesMap subject
+        let triplesMapSubject = null
+        for (const quad of store.match(null, rdfType, namedNode(`${rr}TriplesMap`))) {
+          if (triplesMapSubject) {
+            setError("More than 1 TriplesMap has been found in the RML mappings. The LDWizard currently only supports defining 1 TripleMap.");
+            break;
+          } else {
+            triplesMapSubject = quad.subject
+          }
+        }
+
+        // Get the SubjectMap (subMap, which col is used to generate the subject)
+        let subjectMapValue = null
+        for (const subjectMapQuad of store.match(triplesMapSubject, namedNode(`${rr}subjectMap`), null)) {
+          for (const subMapTemplateQuad of store.match(subjectMapQuad.object, namedNode(`${rr}template`), null)) {
+            subjectMapValue = subMapTemplateQuad.object.value;
+          }
+        }
+        const match = subjectMapValue.match(/(.*?)\{(.*?)\}/);
+        if (match) {
+          const baseIri = match[1];
+          const keyColumnName = match[2];
+          setTransformationConfig((state) => {
+            const keyColumnIndex = state.columnConfiguration.findIndex(obj => obj.columnName === keyColumnName);
+            if (keyColumnIndex > -1) {
+              return {
+                ...state,
+                baseIri: baseIri,
+                key: keyColumnIndex
+              };
+            }
+            return {
+              ...state,
+              baseIri: baseIri,
+            };
+          });
+        }
+
+        // Iterate over TriplesMap predicate-object mappings (poMap)
+        for (const poMapQuad of store.match(triplesMapSubject, namedNode(`${rr}predicateObjectMap`), null)) {
+          const poMapSubject = poMapQuad.object
+
+          // Get the object of the predicate-object mapping
+          let poMapObject = null
+          for (const poMapObjectQuad of store.match(poMapSubject, namedNode(`${rr}objectMap`), null)) {
+            poMapObject = poMapObjectQuad.object
+          }
+
+          // Check the predicate of the predicate-object mapping (can be rr:predicate or rr:predicateMap)
+          let poMapPredicate = null
+          for (const poMapPredicateQuad of store.match(poMapSubject, namedNode(`${rr}predicate`), null)) {
+            poMapPredicate = poMapPredicateQuad.object.value
+          }
+          if (!poMapPredicate) {
+            for (const poMapPredicateQuad of store.match(poMapSubject, namedNode(`${rr}predicateMap`), null)) {
+              for (const poMapPredicateConstant of store.match(poMapPredicateQuad.object, namedNode(`${rr}constant`), null)) {
+                poMapPredicate = poMapPredicateConstant.object.value
+              }
+            }
+          }
+
+          // If the predicate is rdf:type we update the resourceClass
+          if (poMapPredicate == rdfType.id) {
+            let triplesMapType = null
+            for (const predObjectMapConstant of store.match(poMapObject, namedNode(`${rr}constant`), null)) {
+              triplesMapType = predObjectMapConstant.object.value
+            }
+            setTransformationConfig((state) => {
+              return {
+                ...state,
+                resourceClass: triplesMapType
+              };
+            });
+          } else {
+            // Handle predicates other than rdf:type
+            let triplesMapObject = null
+            for (const predObjectMapConstant of store.match(poMapObject, namedNode(`${rml}reference`), null)) {
+              triplesMapObject = predObjectMapConstant.object.value
+            }
+            // triplesMapObject is the column name in the CSV, and poMapPredicate is the URI of the predicate
+            setTransformationConfig((state) => {
+              const columnConfig = [...state.columnConfiguration];
+              let i = 0
+              for (const header of columnConfig) {
+                if (header.columnName === triplesMapObject) {
+                  columnConfig[i] = {
+                    columnName: header.columnName,
+                    propertyIri: poMapPredicate
+                  }
+                }
+                i++
+              }
+              return {
+                ...state,
+                columnConfiguration: columnConfig,
+              };
+            });
+          }
+        }
+        setLoading(false);
+        navigate(`/${Step + 1}`);
+      } catch(e) {
+        console.error(e, typeof e)
+        setLoading(false);
+        setError(`Issue loading the RML mapping file: ${e.message}`)
+      }
+    })
+    .catch((e) => {
+      setLoading(false);
+      setError(e.message);
+    });
+  };
+
 
   // Drag and drop event handlers
   const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
@@ -135,69 +287,121 @@ const Upload: React.FC<Props> = ({ }) => {
       <div className={styles.loading}>
         <Stack alignItems="center">
           <Typography variant="body1" gutterBottom>
-            Loading your CVS file
+            Loading your CSV file
           </Typography>
           <CircularProgress />
         </Stack>
 
       </div>
     ) : (
-      <div className={styles.button}
-      onDragOver={(e) => handleDragOver(e)}
-      onDrop={(e) => handleDrop(e)}>
-        <div className={styles.dragDropIndicator}>
-          <Typography variant="body1" color="primary">
-            Drag and Drop Here
+      <>
+        <div className={styles.button}
+        onDragOver={(e) => handleDragOver(e)}
+        onDrop={(e) => handleDrop(e)}>
+          <div className={styles.dragDropIndicator}>
+            <Typography variant="body1" color="primary">
+              Drag and Drop Here
+            </Typography>
+          </div>
+          <Typography variant="body1" gutterBottom>
+            {sourceText}
           </Typography>
-        </div>
-        <Typography variant="body1" gutterBottom>
-          {sourceText}
-        </Typography>
-        <input
-          id="csv-upload"
-          type="file"
-          className={styles.input}
-          onChange={(event) => {
-            if (event.target.files && event.target.files.length === 1) {
-              const sourceFile = event.target.files[0];
-              handleCsvParse(sourceFile);
-            }
-            else {
-              if (event.target.files && event.target.files.length > 0) {
-                setError("You can only upload one file")
-              }
-              else if (event.target.files && event.target.files.length <= 0) {
-                setError("No files selected")
+          <input
+            id="csv-upload"
+            type="file"
+            className={styles.input}
+            onChange={(event) => {
+              if (event.target.files && event.target.files.length === 1) {
+                const sourceFile = event.target.files[0];
+                handleCsvParse(sourceFile);
               }
               else {
-                setError("Invalid CSV file format")
+                if (event.target.files && event.target.files.length > 0) {
+                  setError("You can only upload one file")
+                }
+                else if (event.target.files && event.target.files.length <= 0) {
+                  setError("No files selected")
+                }
+                else {
+                  setError("Invalid CSV file format")
+                }
               }
-            }
-          }}
-          accept="text/csv"
-        />
-        <label htmlFor="csv-upload">
-          <Box textAlign='center'>
-            <Button component="span" variant="contained" style={{textTransform: 'none'}} startIcon={<FontAwesomeIcon icon="upload" />}>
-              Load Your CSV File
-            </Button>
-          </Box>
-          {error && <Alert severity="error"><AlertTitle>Error</AlertTitle>{error}</Alert>}
-        </label>
-        {exampleFile && (
-          <Typography style={{ paddingTop: "1rem" }}>
-            Or try it with an{" "}
-            <a
-              style={{ cursor: "pointer" }}
-              onClick={() => {
-                handleCsvParse(exampleFile);
-              }}
-            >
-              example CSV file
-            </a>
-          </Typography>
-        )}
-      </div>
+            }}
+            accept="text/csv"
+          />
+          <label htmlFor="csv-upload">
+            <Box textAlign='center'>
+              <Button component="span" variant="contained" style={{textTransform: 'none'}} startIcon={<FontAwesomeIcon icon="upload" />}>
+                Load Your CSV File
+              </Button>
+            </Box>
+          </label>
+          {exampleFile && (
+            <Typography style={{ paddingTop: "1rem" }}>
+              Or try it with an{" "}
+              <a
+                style={{ cursor: "pointer" }}
+                onClick={() => {
+                  handleCsvParse(exampleFile);
+                }}
+              >
+                example CSV file
+              </a>
+            </Typography>
+          )}
+        </div>
+
+        {source &&
+          <>
+            <Typography variant="body1" style={{ textAlign: "center", paddingTop: "2rem" }}>
+              Optionally you can provide a RML or YARRRML mapping file to pre-load the mappings from, or click next
+            </Typography>
+            <div className={styles.button}
+            onDragOver={(e) => handleDragOver(e)}
+            onDrop={(e) => handleDrop(e)}>
+              <div className={styles.dragDropIndicator}>
+                <Typography variant="body1" color="primary">
+                  Drag and Drop Here
+                </Typography>
+              </div>
+              <Typography variant="body1" gutterBottom>
+                {mappingSourceText}
+              </Typography>
+              <input
+                id="rml-upload"
+                type="file"
+                className={styles.input}
+                onChange={(event) => {
+                  if (event.target.files && event.target.files.length === 1) {
+                    const sourceFile = event.target.files[0];
+                    handleRmlParse(sourceFile);
+                  }
+                  else {
+                    if (event.target.files && event.target.files.length > 0) {
+                      setError("You can only upload one file")
+                    }
+                    else if (event.target.files && event.target.files.length <= 0) {
+                      setError("No files selected")
+                    }
+                    else {
+                      setError("Invalid RML file format")
+                    }
+                  }
+                }}
+                accept="text/turtle"
+              />
+              <label htmlFor="rml-upload">
+                <Box textAlign='center'>
+                  <Button component="span" variant="contained" style={{textTransform: 'none'}} startIcon={<FontAwesomeIcon icon="upload" />}>
+                    Load your mapping file
+                  </Button>
+                </Box>
+              </label>
+            </div>
+          </>
+        }
+        {error && <Alert severity="error"><AlertTitle>Error</AlertTitle>{error}</Alert>}
+      </>
       )}
     </>
   );

--- a/src/containers/Upload/index.tsx
+++ b/src/containers/Upload/index.tsx
@@ -171,13 +171,16 @@ const Upload: React.FC<Props> = ({ }) => {
             subjectMapValue = subMapTemplateQuad.object.value;
           }
         }
+        //
         if (subjectMapValue) {
           const match = subjectMapValue.match(regexExtractTemplate);
           if (match) {
             const baseIri = match[1];
             const keyColumnName = match[2];
             setTransformationConfig((state) => {
-              const keyIndex = state.columnConfiguration.findIndex(obj => obj.columnName === keyColumnName);
+              const keyIndex = (keyColumnName === "_rowNumber")
+                ? undefined
+                : state.columnConfiguration.findIndex(obj => obj.columnName === keyColumnName);
               if (keyIndex > -1) {
                 return {
                   ...state,

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -9,6 +9,11 @@ export const sourceState = atom<File | string | undefined>({
   default: undefined,
 });
 
+export const mappingSourceState = atom<File | string | undefined>({
+  key: "mappingSource",
+  default: undefined,
+});
+
 const matrixAtom = atom<Matrix | undefined>({
   key: "matrix",
   default: undefined,
@@ -37,7 +42,7 @@ export const matrixState = selector({
       reset(matrixAtom);
     } else {
       set(matrixAtom, newValue);
-      if (newValue) { 
+      if (newValue) {
         set(transformationConfigState, (state) => {
           return {
             ...state,

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -26,6 +26,9 @@ export function getBasePredicateIri(baseIri: string) {
   return baseIri + "def/";
 }
 export function getBaseIdentifierIri(baseIri: string) {
+  if (baseIri.endsWith("/id/") || baseIri.endsWith("/id#")) {
+    return baseIri
+  }
   if (baseIri.endsWith("#")) {
     return baseIri.slice(0, -1) + "/id#";
   }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -11,7 +11,7 @@ export function cleanCsvValue(value: unknown) {
   if (typeof value === "string"){
     result = encodeURI(value.replace(/ /g, "_"));
     return result
-  } 
+  }
   if (typeof value === "number"){
     result = "" + value;
     return result

--- a/webpack/runtimeConfig.ts
+++ b/webpack/runtimeConfig.ts
@@ -1,5 +1,7 @@
 /**
- * This file is a placeHolder to be used during development. The LDWizard-build script will replace the config file
+ * This file is a placeHolder to be used during development, or as reference by users.
+ * It provides examples for every parameters of the LDWizard,
+ * such as class/predicate search config, column refinements, allowed prefixes...
  */
 //ts-ignores needed due to differing ts-configs in webpack vs src directory
 //@ts-ignore
@@ -24,6 +26,23 @@ let runtimeConfig: WizardConfig = {
   primaryColor: "#4caf50", // green
   secondaryColor: "#1565c0", // blue
   exampleCSV,
+
+  homepageMarkdown: `Example LDWizard for development, a tool to easily map CSV to RDF.`,
+  publishOrder: [ "download" as const ],
+  newDatasetAccessLevel: "internal" as const,
+  repositoryLink: "https://github.com/pldn/LDWizard",
+  documentationLink: "https://github.com/pldn/LDWizard/blob/main/CONFIGURING.md",
+  dataplatformLink: "https://lov.linkeddata.es/dataset/lov/sparql",
+
+  classConfig: {
+      method: "sparql" as const,
+      endpoint: "https://lov.linkeddata.es/dataset/lov/sparql"
+  },
+  predicateConfig: {
+      method:"sparql" as const,
+      endpoint: "https://lov.linkeddata.es/dataset/lov/sparql"
+  },
+
   columnRefinements: [
     {
       label: "Use bulk processing: add '-processed-in-bulk' at the end of literal",
@@ -140,6 +159,68 @@ select ?transformed ?obj where {
       targetShape: "http://pldn.nl/ldwizard/Philosopher",
     },
   ],
+
+
+  getAllowedPrefixes: async () => {
+    return [
+      {
+          "prefixLabel": "dc",
+          "iri": "http://purl.org/dc/elements/1.1/"
+      },
+      {
+          "prefixLabel": "dcat",
+          "iri": "http://www.w3.org/ns/dcat#"
+      },
+      {
+          "prefixLabel": "dct",
+          "iri": "http://purl.org/dc/terms/"
+      },
+      {
+          "prefixLabel": "foaf",
+          "iri": "http://xmlns.com/foaf/0.1/"
+      },
+      {
+          "prefixLabel": "owl",
+          "iri": "http://www.w3.org/2002/07/owl#"
+      },
+      {
+          "prefixLabel": "prov",
+          "iri": "http://www.w3.org/ns/prov#"
+      },
+      {
+          "prefixLabel": "pav",
+          "iri": "http://purl.org/pav/"
+      },
+      {
+          "prefixLabel": "rdf",
+          "iri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      },
+      {
+          "prefixLabel": "rdfa",
+          "iri": "http://www.w3.org/ns/rdfa#"
+      },
+      {
+          "prefixLabel": "rdfs",
+          "iri": "http://www.w3.org/2000/01/rdf-schema#"
+      },
+      {
+          "prefixLabel": "schema",
+          "iri": "https://schema.org/"
+      },
+      {
+          "prefixLabel": "skos",
+          "iri": "http://www.w3.org/2004/02/skos/core#"
+      },
+      {
+          "prefixLabel": "void",
+          "iri": "http://rdfs.org/ns/void#"
+      },
+      {
+          "prefixLabel": "xsd",
+          "iri": "http://www.w3.org/2001/XMLSchema#"
+      },
+    ]
+  },
 };
 
 useRuntimeConfigFile ? (wizardConfig = runtimeConfig) : (wizardConfig = {});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1455,6 +1455,179 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
+"@graphy/content.nq.read@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/content.nq.read/-/content.nq.read-4.3.4.tgz#51d772ee2513dd8f39258bb355a3d81598d673d3"
+  integrity sha512-Z438rZfkfzn7MgpCZGDfdA7zlkMEsc2sF/egTkiyqXj2tjLg3cQKdMYADcFQBxozk0bPqhsqCN3GWjYvE+R/Lg==
+  dependencies:
+    "@graphy/core.data.factory" "^4.3.4"
+    "@graphy/core.iso.stream" "^4.3.4"
+
+"@graphy/content.nq.scan@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/content.nq.scan/-/content.nq.scan-4.3.4.tgz#8097b3084c39cb3a96b046024e9107d518ac0203"
+  integrity sha512-HotUn/7McichndhNrRXCcdmM3Mb8HZ4qPb30MG4KZRHoE/xDZoxcL7Gp636eXCqSXdpx8AuX+UgIEstxmCGz2Q==
+  dependencies:
+    "@graphy/core.data.factory" "^4.3.4"
+
+"@graphy/content.nq.scribe@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/content.nq.scribe/-/content.nq.scribe-4.3.4.tgz#1b782c9a36eedcfffb6eb1b3718ed58bf3898be3"
+  integrity sha512-R9bZ26wpCHX19xNxJKhAOKYGCAokQIBtmSJWkpYYwwlJ8G5bJ7UV+TKKfYq18MOha8kM9q62caqnNVU7zeJKPA==
+  dependencies:
+    "@graphy/core.class.writable" "^4.3.4"
+    "@graphy/core.data.factory" "^4.3.4"
+
+"@graphy/content.nq.write@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/content.nq.write/-/content.nq.write-4.3.4.tgz#2f99a0a60263e326e43c6de04b93940efc947e44"
+  integrity sha512-wtn3zLfx9q2X28zVjm7ltdq9yBSB7Le7zaC4uTzAOUicBuZcGGOJ9VNb5lQaNAhAW6i2uMD6ruW0UeGgBHR5lg==
+  dependencies:
+    "@graphy/core.class.writable" "^4.3.4"
+    "@graphy/core.data.factory" "^4.3.4"
+
+"@graphy/content.nt.read@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/content.nt.read/-/content.nt.read-4.3.4.tgz#d69c6fc3814ee692310525b1329ee35e7e8ae996"
+  integrity sha512-lbnzvepeZeYPsfReFsgLCwP9ntP8UUiojAb/bXQoqrSV+wtfUr46RdaKqn4Jokm5uQcvf9N9dgBmMuTtlSHXTQ==
+  dependencies:
+    "@graphy/core.data.factory" "^4.3.4"
+    "@graphy/core.iso.stream" "^4.3.4"
+
+"@graphy/content.nt.scan@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/content.nt.scan/-/content.nt.scan-4.3.4.tgz#3bb78e865aba31df598b07718b8e4453875495d8"
+  integrity sha512-t6G6CciBLrotMPyKYAl+xVyiyBKrcNJKCVSQb3lm0DIQYR6pUJ2yLLDuIzsSrEnoXfIVUtrETZBAnRBejs15Dg==
+  dependencies:
+    "@graphy/core.data.factory" "^4.3.4"
+
+"@graphy/content.nt.scribe@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/content.nt.scribe/-/content.nt.scribe-4.3.4.tgz#8632daea1d3fcb6c657d181fbbbcc1c84095aefc"
+  integrity sha512-hPV6OaylipcHZOMO8H5wHLBGLQqwxZaQNJhiU2tuVbO7ZBhFtxTAxHlNkoII+vH2iDWGHX385+ljVc2A/MsBTw==
+  dependencies:
+    "@graphy/core.class.writable" "^4.3.4"
+    "@graphy/core.data.factory" "^4.3.4"
+
+"@graphy/content.nt.write@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/content.nt.write/-/content.nt.write-4.3.4.tgz#a92189820b3f6c96e28051edec5082906556f3c3"
+  integrity sha512-WAHo/lbBAqySa9t6uN+c5qHDj08Ec+o4xAwPSWSfP5ZufxM3OkgQyMBITmHy0IG28Ckf6Akjo7/w2oNXOSlskQ==
+  dependencies:
+    "@graphy/core.class.writable" "^4.3.4"
+    "@graphy/core.data.factory" "^4.3.4"
+
+"@graphy/content.trig.read@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/content.trig.read/-/content.trig.read-4.3.4.tgz#fdfba0e66b8bfb928de82660904bbb0197b3e7db"
+  integrity sha512-kShOOxR/OgK/cX/rlkcAyGtwc2kPdvQv2KBEMrrqGLMwQoRUDZiYOZlwepmRTX84KR3gYXpCh78OsftjuIVAiA==
+  dependencies:
+    "@graphy/core.data.factory" "^4.3.4"
+    "@graphy/core.iso.stream" "^4.3.4"
+    uri-js "^4.4.0"
+
+"@graphy/content.trig.scribe@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/content.trig.scribe/-/content.trig.scribe-4.3.4.tgz#5d73d8add3705cbf8ad01cef304e973d87c255c4"
+  integrity sha512-wj3gu25uVIAjl2ZWGw4Q3PTJF2CcFs7pvOI2nJfatdJKzRczj1xjpARNw5jNydQDsl0ltpyeCEiL186r+3AaBA==
+  dependencies:
+    "@graphy/core.class.writable" "^4.3.4"
+    "@graphy/core.data.factory" "^4.3.4"
+
+"@graphy/content.trig.write@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/content.trig.write/-/content.trig.write-4.3.4.tgz#1b838dc36aa21c761462222303ab2c8383740377"
+  integrity sha512-mRQF/B/KZV1b1isw+UOJUm7auzwnfqUt7U670mNjTpa5fdfnqVWtMIEPMkD2o+Wis87UKejjUojNPAFfFBZ85g==
+  dependencies:
+    "@graphy/core.class.writable" "^4.3.4"
+    "@graphy/core.data.factory" "^4.3.4"
+    big-integer "^1.6.48"
+
+"@graphy/content.ttl.read@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/content.ttl.read/-/content.ttl.read-4.3.4.tgz#2af56c12e5ab826e953ab7967ed5ecde3653ee76"
+  integrity sha512-SYXQHEmr0eW8cCCDRnKp7c08Xq8Mgjumnk+2RefdvkrUcDCceeNmaNtw9negZKWw1AEyw/VsD+iEZCr0+LEf6g==
+  dependencies:
+    "@graphy/core.data.factory" "^4.3.4"
+    "@graphy/core.iso.stream" "^4.3.4"
+    uri-js "^4.4.0"
+
+"@graphy/content.ttl.scribe@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/content.ttl.scribe/-/content.ttl.scribe-4.3.4.tgz#785bf697d8ee72f8312681629ccd84044b541cb9"
+  integrity sha512-k9gxM+Yh7xxru3Kunxk8n+rxzRLsLooidXt9leQw/SaGLpxyWUYF0MUR6yc4Epal1j6cWZxXFBAUGKnP4+w5Wg==
+  dependencies:
+    "@graphy/core.class.writable" "^4.3.4"
+    "@graphy/core.data.factory" "^4.3.4"
+
+"@graphy/content.ttl.write@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/content.ttl.write/-/content.ttl.write-4.3.4.tgz#58335abec9afddb81d034298b65981477efe3352"
+  integrity sha512-riXl3z7xP6cVG9rnBtpDckmMFikVQr3kcmfTMR3mB+LTR3JAMO5BGS5NOHu5kWW4wKTCvS6rJRD5N+WrxeDxtg==
+  dependencies:
+    "@graphy/core.class.writable" "^4.3.4"
+    "@graphy/core.data.factory" "^4.3.4"
+    big-integer "^1.6.48"
+
+"@graphy/content.xml.scribe@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/content.xml.scribe/-/content.xml.scribe-4.3.4.tgz#dc836f9bbdf8c5f2740319cd9a0538f639be1bdb"
+  integrity sha512-SkcQB5lBzFs73KupxiLgpsdtblU7W8AtalWEVeHEXq7RaQSi/ogE3d/6kTXYbMghdDHr2aGRpuHA+epivbfY5w==
+  dependencies:
+    "@graphy/core.class.writable" "^4.3.4"
+    "@graphy/core.data.factory" "^4.3.4"
+
+"@graphy/core.class.scribable@4.3.4", "@graphy/core.class.scribable@^4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/core.class.scribable/-/core.class.scribable-4.3.4.tgz#28c15d35c343537f4ea16ce401e258f1a3c8a16a"
+  integrity sha512-miZ/rYApkl6jLIxRUWlh0KxDaV2GQVzY9Ejn1zJ71FxYfRfkQRf6ToV7aKQfySlkehFfBrVnzHe9WgZqNQz6Mg==
+  dependencies:
+    "@graphy/core.data.factory" "^4.3.4"
+    "@graphy/core.iso.stream" "^4.3.4"
+
+"@graphy/core.class.writable@4.3.4", "@graphy/core.class.writable@^4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/core.class.writable/-/core.class.writable-4.3.4.tgz#e632384a0b263cdc67c1b6b82ae5839ef4692e19"
+  integrity sha512-B1dhE/Kg/jVgXUW7scgKVfNJC5IHs7tT81DZRs7Vt6zdqwM4bi3fgEfUb2dTe40PetUY7gu5qR2sXXn06UtoQw==
+  dependencies:
+    "@graphy/core.class.scribable" "^4.3.4"
+    "@graphy/core.data.factory" "^4.3.4"
+
+"@graphy/core.data.factory@4.3.4", "@graphy/core.data.factory@^4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/core.data.factory/-/core.data.factory-4.3.4.tgz#738998f1785e79b245dcb02afafc1c281926100e"
+  integrity sha512-IH/WkKG6kqfqNGgHIAseYXHkQTvWvjQsuDrfy+1IvOhFzJC8hRhqcBlse7ik4Cc7lzoWZWd6alQU3RA89D7nmw==
+  dependencies:
+    uri-js "^4.4.0"
+
+"@graphy/core.iso.stream@4.3.4", "@graphy/core.iso.stream@^4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/core.iso.stream/-/core.iso.stream-4.3.4.tgz#f275c123d075ee9cc3a71526553e89658caaafc9"
+  integrity sha512-b66gmPVFC1a6RflI423Joq2gZ1BlIBfr2CiKChSzqlAYgzFWqQSKcI6ECP7gctZdezNc3h54t1+FljxPef3Ufg==
+  dependencies:
+    readable-stream "^3.6.0"
+
+"@graphy/core.iso.threads@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/core.iso.threads/-/core.iso.threads-4.3.4.tgz#15297ef99c7012e40f5c8ba9bec7923fdd9d6f91"
+  integrity sha512-1/oFgPCxNmSHFZu73pVJhsEMtP26GMXKQ5Dco1tNgkSxr0PbTmZbgB6yWfMMn56eeIfsT27O88fq2TfQZBsVOw==
+
+"@graphy/memory.dataset.fast@4.3.6":
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/@graphy/memory.dataset.fast/-/memory.dataset.fast-4.3.6.tgz#26031b65c282212cbee77026489bdfb864b47541"
+  integrity sha512-kZMMnspws8YSnRLrP/mQukW6bhoYB+lVmvOS7BtbC3O8p0hP8xvJf8s52wkAYfSBfDqwd+1yl8mh9xJ+hlJMtQ==
+  dependencies:
+    "@graphy/core.data.factory" "^4.3.4"
+    "@graphy/core.iso.stream" "^4.3.4"
+
+"@graphy/util.dataset.tree@4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@graphy/util.dataset.tree/-/util.dataset.tree-4.3.4.tgz#1997f0379e9c39c407ad409cbec0e035180fccd8"
+  integrity sha512-S9OxPWH3nWiHBxKvPjnDKUL3ISp9EVZWQZUhul4ruSKbPAchliyTF74p1TmrGzbMF5SVfqanAvlgpOq7LJueMA==
+  dependencies:
+    "@graphy/core.data.factory" "^4.3.4"
+    "@graphy/core.iso.stream" "^4.3.4"
+
 "@humanwhocodes/config-array@^0.11.10":
   version "0.11.11"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.11.tgz#88a04c570dbbc7dd943e4712429c3df09bc32844"
@@ -1874,6 +2047,24 @@
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.8.0.tgz#e848d2f669f601544df15ce2a313955e4bf0bafc"
   integrity sha512-mrfKqIHnSZRyIzBcanNJmVQELTnX+qagEDlcKO90RgRBVOZGSGvZKeDihTRfWcqoDn5N/NkUcwWTccnpN18Tfg==
+
+"@rmlio/yarrrml-parser@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@rmlio/yarrrml-parser/-/yarrrml-parser-1.6.1.tgz#a02958477dc6f1c916cc4bb6dce6741a6d942000"
+  integrity sha512-FAeWZKf1cOnCHZHNRBfB4r0IHmv2pxrpcaHAMEg+LyeP1rnTPKwPAgINXeczf5HB0hKJQebXGLNMFz2xSuuEJA==
+  dependencies:
+    commander "^9.4.1"
+    extend "^3.0.2"
+    glob "^8.0.3"
+    graphy "^4.3.5"
+    js-logger "^1.6.1"
+    n3 "^1.16.3"
+    parse-author "^2.0.0"
+    pkginfo "^0.4.1"
+    prefix-ns "^0.1.2"
+    q "^1.5.1"
+    rdf-isomorphic "^1.3.1"
+    yamljs "^0.3.0"
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
@@ -3016,6 +3207,11 @@ attr-accept@^2.0.0:
   resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
   integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
 
+author-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/author-regex/-/author-regex-1.0.0.tgz#d08885be6b9bbf9439fe087c76287245f0a81450"
+  integrity sha512-KbWgR8wOYRAPekEmMXrYYdc7BRyhn2Ftk7KWfMUnQ43hFdojWEFRxhhRUm3/OFEdPa1r0KAvTTg9YQK57xTe0g==
+
 autocast@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/autocast/-/autocast-0.0.4.tgz#ece7d92527ca37ea502f99e8f41fe44daf00dbce"
@@ -3094,6 +3290,11 @@ batch@0.6.1:
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==
 
+big-integer@^1.6.48:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -3103,6 +3304,11 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+bkit@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/bkit/-/bkit-2.1.3.tgz#0511f01c043ce11affb9531e810b09a80514eefa"
+  integrity sha512-mgjJ0c8gx9secFYhU/WZIA4LuhtzVOlQQuuyWJUbL0aTs6cZT+P2Bpa86kOP8lsf64pd8NpM5fgo529AgZTt0Q==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   version "4.12.0"
@@ -3414,7 +3620,7 @@ camelcase-keys@^6.2.2:
     map-obj "^4.0.0"
     quick-lru "^4.0.1"
 
-camelcase@^5.3.1:
+camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -3593,6 +3799,15 @@ cli-truncate@^3.1.0:
     slice-ansi "^5.0.0"
     string-width "^5.0.0"
 
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
+
 cliui@^7.0.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
@@ -3718,6 +3933,11 @@ commander@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+
+commander@^9.4.1:
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
+  integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
 
 common-path-prefix@^3.0.0:
   version "3.0.0"
@@ -4812,6 +5032,11 @@ express@^4.17.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+extend@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -5107,7 +5332,7 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-get-caller-file@^2.0.5:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -5175,7 +5400,7 @@ glob@7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -5187,7 +5412,7 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.1:
+glob@^8.0.1, glob@^8.0.3:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
   integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
@@ -5279,6 +5504,41 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+graphy@^4.3.5:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/graphy/-/graphy-4.3.6.tgz#c41e3101e7acf999af959a571aba5eeb72ae3ff0"
+  integrity sha512-c3DgFi3otWz8+SYNeL9hMCgV/09QAeP4rvd5DdAWMe4vgBRvZk3H48nx/35XMXmvIpR4qgnUsnh8ov/C8kXHAQ==
+  dependencies:
+    "@graphy/content.nq.read" "4.3.4"
+    "@graphy/content.nq.scan" "4.3.4"
+    "@graphy/content.nq.scribe" "4.3.4"
+    "@graphy/content.nq.write" "4.3.4"
+    "@graphy/content.nt.read" "4.3.4"
+    "@graphy/content.nt.scan" "4.3.4"
+    "@graphy/content.nt.scribe" "4.3.4"
+    "@graphy/content.nt.write" "4.3.4"
+    "@graphy/content.trig.read" "4.3.4"
+    "@graphy/content.trig.scribe" "4.3.4"
+    "@graphy/content.trig.write" "4.3.4"
+    "@graphy/content.ttl.read" "4.3.4"
+    "@graphy/content.ttl.scribe" "4.3.4"
+    "@graphy/content.ttl.write" "4.3.4"
+    "@graphy/content.xml.scribe" "4.3.4"
+    "@graphy/core.class.scribable" "4.3.4"
+    "@graphy/core.class.writable" "4.3.4"
+    "@graphy/core.data.factory" "4.3.4"
+    "@graphy/core.iso.stream" "4.3.4"
+    "@graphy/core.iso.threads" "4.3.4"
+    "@graphy/memory.dataset.fast" "4.3.6"
+    "@graphy/util.dataset.tree" "4.3.4"
+    big-integer "^1.6.48"
+    bkit "^2.1.3"
+    chalk "^4.1.0"
+    pegjs "^0.10.0"
+    readable-stream "^3.6.0"
+    uri-js "^4.4.0"
+    yargs "^15.4.1"
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -5369,7 +5629,7 @@ hash-base@^3.0.0:
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
 
-hash.js@^1.0.0, hash.js@^1.0.3:
+hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
@@ -5939,6 +6199,11 @@ js-base64@^2.4.9, js-base64@^2.6.1:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
   integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
+
+js-logger@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/js-logger/-/js-logger-1.6.1.tgz#8f09671b515e4a6f31dced8fdb8923432e2c60af"
+  integrity sha512-yTgMCPXVjhmg28CuUH8CKjU+cIKL/G+zTu4Fn4lQxs8mRFH/03QTNvEFngcxfg/gRDiQAOoyCKmMTOm9ayOzXA==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -7272,6 +7537,13 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
 
+parse-author@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-author/-/parse-author-2.0.0.tgz#d3460bf1ddd0dfaeed42da754242e65fb684a81f"
+  integrity sha512-yx5DfvkN8JsHL2xk2Os9oTia467qnvRgey4ahSm2X8epehBLx/gWLcy5KI+Y36ful5DzGbCS6RazqZGgy1gHNw==
+  dependencies:
+    author-regex "^1.0.0"
+
 parse-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
@@ -7390,6 +7662,11 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pegjs@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/pegjs/-/pegjs-0.10.0.tgz#cf8bafae6eddff4b5a7efb185269eaaf4610ddbd"
+  integrity sha512-qI5+oFNEGi3L5HAxDwN2LA4Gg7irF70Zs25edhjld9QemOgp0CbvMtbFcMvFtEo1OityPrcCzkQFB8JP/hxgow==
+
 picocolors@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f"
@@ -7428,6 +7705,11 @@ pkg-dir@^7.0.0:
   integrity sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==
   dependencies:
     find-up "^6.3.0"
+
+pkginfo@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
+  integrity sha512-8xCNE/aT/EXKenuMDZ+xTVwkT8gsoHN2z/Q29l80u0ppGEXVvsKRzNMbtKhg8LS8k1tJLAHHylf6p4VFmP6XUQ==
 
 plumb@0.1.0:
   version "0.1.0"
@@ -7717,6 +7999,11 @@ postcss@^8.4.21, postcss@^8.4.24:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+prefix-ns@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/prefix-ns/-/prefix-ns-0.1.2.tgz#500399b6e963a8c702287ce847851f86bd9ac738"
+  integrity sha512-sMfjexR5XMvZfZBm7Amb44OpzWgT7wwvOq9wAgLGAwsb7j12c7ZMXZa98SgCyySD6YyevGjK3cj0e+O0T+FCgA==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -7832,6 +8119,11 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
 
+q@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
+  integrity sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==
+
 qs@6.11.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
@@ -7928,6 +8220,16 @@ rdf-data-factory@^1.1.0, rdf-data-factory@^1.1.1, rdf-data-factory@^1.1.2:
   dependencies:
     "@rdfjs/types" "*"
 
+rdf-isomorphic@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/rdf-isomorphic/-/rdf-isomorphic-1.3.1.tgz#cd6d433cd85bf79d903d5f0fdeea42a40eb27265"
+  integrity sha512-6uIhsXTVp2AtO6f41PdnRV5xZsa0zVZQDTBdn0br+DZuFf5M/YD+T6m8hKDUnALI6nFL/IujTMLgEs20MlNidQ==
+  dependencies:
+    "@rdfjs/types" "*"
+    hash.js "^1.1.7"
+    rdf-string "^1.6.0"
+    rdf-terms "^1.7.0"
+
 rdf-js@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/rdf-js/-/rdf-js-4.0.2.tgz#f01510528bbfc6e004012b71a8a533896c4c4c10"
@@ -7935,13 +8237,22 @@ rdf-js@^4.0.2:
   dependencies:
     "@rdfjs/types" "*"
 
-rdf-string@^1.6.2, rdf-string@^1.6.3:
+rdf-string@^1.6.0, rdf-string@^1.6.2, rdf-string@^1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/rdf-string/-/rdf-string-1.6.3.tgz#5c3173fad13e6328698277fb8ff151e3423282ab"
   integrity sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==
   dependencies:
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.0"
+
+rdf-terms@^1.7.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/rdf-terms/-/rdf-terms-1.11.0.tgz#0c2e3a2b43f1042959c9263af27dab08dc4b084d"
+  integrity sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==
+  dependencies:
+    "@rdfjs/types" "*"
+    rdf-data-factory "^1.1.0"
+    rdf-string "^1.6.0"
 
 react-dom@^18.2.0:
   version "18.2.0"
@@ -8173,6 +8484,11 @@ require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
 requires-port@^1.0.0:
   version "1.0.0"
@@ -9262,7 +9578,7 @@ update-browserslist-db@^1.0.11:
     escalade "^3.1.1"
     picocolors "^1.0.0"
 
-uri-js@^4.2.2, uri-js@^4.4.1:
+uri-js@^4.2.2, uri-js@^4.4.0, uri-js@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
@@ -9548,6 +9864,11 @@ whatwg-url@^5.0.0:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
 
+which-module@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.1.tgz#776b1fe35d90aebe99e8ac15eb24093389a4a409"
+  integrity sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==
+
 which-typed-array@^1.1.11, which-typed-array@^1.1.2:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.11.tgz#99d691f23c72aab6768680805a271b69761ed61a"
@@ -9587,6 +9908,15 @@ workerpool@6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
+
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
@@ -9644,6 +9974,11 @@ xtend@^4.0.2, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
+y18n@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
+  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
+
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
@@ -9679,10 +10014,26 @@ yaml@^2.3.1:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.2.tgz#f522db4313c671a0ca963a75670f1c12ea909144"
   integrity sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==
 
+yamljs@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/yamljs/-/yamljs-0.3.0.tgz#dc060bf267447b39f7304e9b2bfbe8b5a7ddb03b"
+  integrity sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==
+  dependencies:
+    argparse "^1.0.7"
+    glob "^7.0.5"
+
 yargs-parser@20.2.4:
   version "20.2.4"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
+
+yargs-parser@^18.1.2:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
 
 yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   version "20.2.9"
@@ -9716,6 +10067,23 @@ yargs@16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^15.4.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.2"
 
 yargs@^17.2.1, yargs@^17.3.1:
   version "17.7.2"


### PR DESCRIPTION
Hi @pietervaneverdingen @philipperenzen , this PR brings the changes to implement exporting mappings to YARRRML, and importing mapping configuration from a previously exported RML or YARRRML file. Fixes https://github.com/pldn/LDWizard/issues/60 

- At the last **Publish** step, users can now choose to download mappings in the YARRRML format
- At the **Upload** step once the CSV file has been loaded an optional button to load a mapping file is shown. Users can provide a RML `.ttl` file, or a YARRRML `.yml` or `.yaml` file (parser will be picked automatically based on the file extention, default to turtle parser). The column transformation config will be automatically extracted from the provided mapping file and loaded for the next step "Configure"
- `_rowNumber` is now properly supported when importing
- The generated RDF output is now in the turtle format, instead of ntriples. The wizardAppConfig is passed to the applyTransformation function (used to execute rocketRML to generate RDF from the mappings), so that we can use the prefixes defined at the app level in the generated Turtle RDF output. Fixes https://github.com/pldn/LDWizard/issues/34

Here is what how it looks like at the **Upload** step:

![Screenshot from 2023-11-13 09-12-10](https://github.com/pldn/LDWizard/assets/3778439/7b1afcf2-46cd-4191-b0bd-1a18cfaaf21e)

Let me know if you would like to change the message about importing mappings.
