### PR TITLE
Fixes 162 & 163: owl same as and keep original value fixes

### DIFF
--- a/CONFIGURING.md
+++ b/CONFIGURING.md
@@ -292,6 +292,7 @@ select ?transformed ?obj where {
       },
       keepOriginalValue: {
         keepValue: true,
+        owlSameAsRelationship:true
       },
     },
     {
@@ -309,10 +310,12 @@ select ?transformed ?obj where {
     },
   ],
   requireShaclShape: true,
-  shaclShapes: [{
-      url: '/Person.ttl',
-      targetShape: 'http://pldn.nl/ldwizard/Philosopher'
-  }]
+  shaclShapes: [
+    {
+      url: shapeFile,
+      targetShape: "http://pldn.nl/ldwizard/Philosopher",
+    },
+  ],
 };
 export default globalThis.wizardConfig = wizardConfig
 ```

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "rm -rf ./webpack/lib ./lib ./webpack/tsconfig-webpack.tsbuildinfo && tsc -p ./tsconfig.json && tsc -p tsconfig-webpack.json && yarn webpack --config ./webpack/lib/config.js  && chmod +x ./webpack/lib/ldwizard-build.js",
     "dev": "yarn --development && tsc -p tsconfig-webpack.json && webpack serve --history-api-fallback --host 0.0.0.0 --port 4000 --hot  --config ./webpack/lib/config.js",
     "start": "yarn build && npx http-server -c-1 ./lib",
-    "ldwizard-build": "./webpack/ldwizard-build.js",
+    "ldwizard-build": "./webpack/lib/ldwizard-build.js",
     "test": "tsc -p ./tsconfig-test.json && mocha $(find ./test -name '*.test.js') --require source-map-support/register",
     "util:analyzeBundle": "ANALYZE_BUNDLE=true yarn run build",
     "util:bundlesize": "bundlesize",

--- a/src/Definitions.ts
+++ b/src/Definitions.ts
@@ -110,6 +110,7 @@ export type KeepOriginalValueOptions = {
   customPredicateIRI?: string
   keepAsIri?: boolean
   keepAsLiteral?: boolean
+  owlSameAsRelationship?: boolean
 }
 /**
  * Define transformation scripts in configuration

--- a/src/config/WizardConfig.d.ts
+++ b/src/config/WizardConfig.d.ts
@@ -16,6 +16,7 @@ export type KeepOriginalValueOptions = {
     customPredicateIRI?: string;
     keepAsIri?: boolean;
     keepAsLiteral?: boolean;
+    owlSameAsRelationship?: boolean;
 };
 export interface BaseColumnRefinement {
     label: string;

--- a/src/config/WizardConfig.ts
+++ b/src/config/WizardConfig.ts
@@ -14,6 +14,7 @@ export type KeepOriginalValueOptions = {
   customPredicateIRI?: string
   keepAsIri?: boolean
   keepAsLiteral?: boolean
+  owlSameAsRelationship?: boolean
 }
 export interface BaseColumnRefinement {
   label: string;

--- a/types/WizardConfig.d.ts
+++ b/types/WizardConfig.d.ts
@@ -13,6 +13,7 @@ export type KeepOriginalValueOptions = {
     customPredicateIRI?: string;
     keepAsIri?: boolean
     keepAsLiteral?: boolean
+    owlSameAsRelationship: boolean
 };
 export interface BaseColumnRefinement {
   label: string;

--- a/webpack/runtimeConfig.ts
+++ b/webpack/runtimeConfig.ts
@@ -13,7 +13,7 @@ import bulkSparql from "../src/utils/bulkSparql.js";
 import { DataFactory } from "n3";
 
 // Turn this to "true" to enable this configuration (for development purposes)
-const useRuntimeConfigFile = false;
+const useRuntimeConfigFile = true;
 
 let wizardConfig: WizardConfig;
 

--- a/webpack/runtimeConfig.ts
+++ b/webpack/runtimeConfig.ts
@@ -25,8 +25,6 @@ let runtimeConfig: WizardConfig = {
   secondaryColor: "#1565c0", // blue
   exampleCSV,
   columnRefinements: [
-    // TODO improve examples
-    // TODO DOC comments for Opts
     {
       label: "Use bulk processing: add '-processed-in-bulk' at the end of literal",
       type: "single",
@@ -119,6 +117,7 @@ select ?transformed ?obj where {
       },
       keepOriginalValue: {
         keepValue: true,
+        owlSameAsRelationship:true
       },
     },
     {

--- a/webpack/runtimeConfig.ts
+++ b/webpack/runtimeConfig.ts
@@ -25,6 +25,8 @@ let runtimeConfig: WizardConfig = {
   secondaryColor: "#1565c0", // blue
   exampleCSV,
   columnRefinements: [
+    // TODO improve examples
+    // TODO DOC comments for Opts
     {
       label: "Use bulk processing: add '-processed-in-bulk' at the end of literal",
       type: "single",


### PR DESCRIPTION
When using `keepOriginalValue`'s `keepValue` the original value will be kept, if in combination the `owlSameAsRelationship` is set to `true` it will model an owl:sameAs relationship with the two generated object values.

This merge also fixes #163 regarding the logic of how Predicate and Customs IRI's handled in the output.